### PR TITLE
support escapePattern of @DataSet annotation

### DIFF
--- a/spring-dbunit-test/src/main/java/com/excilys/ebi/spring/dbunit/test/TestConfigurationProcessor.java
+++ b/spring-dbunit-test/src/main/java/com/excilys/ebi/spring/dbunit/test/TestConfigurationProcessor.java
@@ -118,6 +118,7 @@ public class TestConfigurationProcessor implements ConfigurationProcessor<TestCo
 		.withDbType(annotation.dbType())/**/
 		.withDataSourceSpringName(StringUtils.hasText(annotation.dataSourceSpringName()) ? annotation.dataSourceSpringName() : null)/**/
 		.withDataSetResourceLocations(dataSetResourceLocations)/**/
+		.withEscapePattern(annotation.escapePattern())
 		.build();
 	}
 


### PR DESCRIPTION
This is a fix to add support for escapePattern of @DataSet annotation (else it stays with default escape pattern \"?\")
