### PR TITLE
Adds DataSetDecorators to @DataSet

### DIFF
--- a/spring-dbunit-core/src/main/java/com/excilys/ebi/spring/dbunit/config/DataSetConfiguration.java
+++ b/spring-dbunit-core/src/main/java/com/excilys/ebi/spring/dbunit/config/DataSetConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.util.Assert;
 
 import com.excilys.ebi.spring.dbunit.config.Constants.ConfigurationDefaults;
+import com.excilys.ebi.spring.dbunit.dataset.DataSetDecorator;
 
 /**
  * @author <a href="mailto:slandelle@excilys.com">Stephane LANDELLE</a>
@@ -50,6 +51,7 @@ public class DataSetConfiguration implements DatabaseConnectionConfigurer {
 	private boolean skipOracleRecycleBinTables = ConfigurationDefaults.DEFAULT_SKIP_ORACLE_RECYCLEBIN_TABLES;
 	private String[] tableType = ConfigurationDefaults.DEFAULT_TABLE_TYPE;
 	private String schema = ConfigurationDefaults.DEFAULT_SCHEMA;
+	private Class<? extends DataSetDecorator>[] decorators = null;
 
 	public IDataSet getDataSet() throws DataSetException, IOException {
 
@@ -166,6 +168,12 @@ public class DataSetConfiguration implements DatabaseConnectionConfigurer {
 			if (!schema.isEmpty())
 				dataSetConfiguration.schema = schema;
 			return this;
+		}
+
+		public Builder withDecorators(Class<? extends DataSetDecorator>[] decorators) {
+		    if(decorators != null)
+		        dataSetConfiguration.decorators = decorators;
+		    return this;
 		}
 
 		public DataSetConfiguration build() throws DataSetException, IOException {
@@ -316,4 +324,12 @@ public class DataSetConfiguration implements DatabaseConnectionConfigurer {
 	public void setSchema(String schema) {
 		this.schema = schema;
 	}
+
+    public Class<? extends DataSetDecorator>[] getDecorators() {
+        return decorators;
+    }
+
+    public void setDecorators(Class<? extends DataSetDecorator>[] decorators) {
+        this.decorators = decorators;
+    }
 }

--- a/spring-dbunit-core/src/main/java/com/excilys/ebi/spring/dbunit/dataset/DataSetDecorator.java
+++ b/spring-dbunit-core/src/main/java/com/excilys/ebi/spring/dbunit/dataset/DataSetDecorator.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2001-2014 Group JCDecaux. 
+ * 17 rue Soyer, 92523 Neuilly Cedex, France.
+ * All rights reserved. 
+ * 
+ * This software is the confidential and proprietary information
+ * of Group JCDecaux ("Confidential Information").  You shall not
+ * disclose such Confidential Information and shall use it only
+ * in accordance with the terms of the license agreement you
+ * entered into with Group JCDecaux.
+ */
+
+package com.excilys.ebi.spring.dbunit.dataset;
+
+public interface DataSetDecorator {
+    String getStringToReplace();
+    
+    String getStringReplacement();
+}

--- a/spring-dbunit-test/src/main/java/com/excilys/ebi/spring/dbunit/test/DataSet.java
+++ b/spring-dbunit-test/src/main/java/com/excilys/ebi/spring/dbunit/test/DataSet.java
@@ -24,11 +24,13 @@ import java.lang.annotation.Target;
 
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.dataset.IDataSet;
+import org.springframework.core.DecoratingClassLoader;
 
 import com.excilys.ebi.spring.dbunit.config.Constants.ConfigurationDefaults;
 import com.excilys.ebi.spring.dbunit.config.DBOperation;
 import com.excilys.ebi.spring.dbunit.config.DBType;
 import com.excilys.ebi.spring.dbunit.config.DataSetFormat;
+import com.excilys.ebi.spring.dbunit.dataset.DataSetDecorator;
 
 /**
  * Indicates that a test class or a test method has to load and purge the
@@ -159,4 +161,9 @@ public @interface DataSet {
 	 * @return the schema
 	 */
 	String schema() default "";
+
+	/**
+	 * @return decorators to be applied on the dataset
+	 */
+	Class<? extends DataSetDecorator>[] decorators() default {};
 }

--- a/spring-dbunit-test/src/main/java/com/excilys/ebi/spring/dbunit/test/TestConfigurationProcessor.java
+++ b/spring-dbunit-test/src/main/java/com/excilys/ebi/spring/dbunit/test/TestConfigurationProcessor.java
@@ -158,6 +158,7 @@ public class TestConfigurationProcessor implements ConfigurationProcessor<TestCo
 		.withTableType(annotation.tableType())/**/
 		.withQualifiedTableNames(annotation.qualifiedTableNames())/**/
 		.withSchema(annotation.schema())/**/
+		.withDecorators(annotation.decorators())
 		.build();
 	}
 


### PR DESCRIPTION
This feature aims at allowing users of the library to use tokens in their XML datasets so that they can replace them with dynamically computed values.

For instance, I use it to replace [NOW] with the date on which the dataset is loaded.
This is extremely useful when testing date dependant services.

Maybe Spring-DBUnit could then ship several default DataSetDecorators?
